### PR TITLE
Feature: Add new migration for different nodeTypes in versions

### DIFF
--- a/Classes/Transformations/DetachVariantsWithDifferentNodeTypesTransformation.php
+++ b/Classes/Transformations/DetachVariantsWithDifferentNodeTypesTransformation.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace VIVOMEDIA\Neos9\Upgrade\Transformations;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Neos\ContentRepository\Domain\Model\NodeData;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\ContentRepository\Migration\Transformations\AbstractTransformation;
+use Neos\Flow\Utility\Algorithms;
+use Neos\Flow\Annotations as Flow;
+
+class DetachVariantsWithDifferentNodeTypesTransformation extends AbstractTransformation
+{
+    /**
+     * @Flow\Inject
+     * @var NodeDataRepository
+     */
+    protected $nodeDataRepository;
+    /**
+     * @Flow\Inject
+     * @var EntityManagerInterface
+     */
+    protected $entityManager;
+
+    /**
+     * @param NodeData $node
+     * @return boolean
+     */
+    public function isTransformable(NodeData $node)
+    {
+        $variants = $this->nodeDataRepository->findByNodeIdentifier($node->getIdentifier())->toArray();
+        if (empty($variants)) {
+            return false;
+        }
+        $nodeTypes = [];
+        foreach ($variants as $variant) {
+            if (isset($nodeTypes[$variant->getNodeType()->getName()])) {
+                $nodeTypes[$variant->getNodeType()->getName()]++;
+            } else {
+                $nodeTypes[$variant->getNodeType()->getName()] = 1;
+            }
+        }
+        if (count($nodeTypes) == 1) {
+            return false;
+        }
+        if ($nodeTypes[$node->getNodeType()->getName()] == 1 && count($variants) > 1) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Generate a new identifier to detach the variant from the other variants
+     *
+     * @param NodeData $node
+     * @return void
+     */
+    public function execute(NodeData $node)
+    {
+        $identifier = Algorithms::generateUUID();
+        $node->setIdentifier($identifier);
+    }
+}

--- a/Migrations/ContentRepository/Version20250403150125.yaml
+++ b/Migrations/ContentRepository/Version20250403150125.yaml
@@ -1,0 +1,14 @@
+up:
+  comments: 'Detach variants with different nodeType'
+  migration:
+    - filters:
+        - type: 'NodeType'
+          settings:
+            nodeType: 'Neos.Neos:Node'
+            withSubTypes: TRUE
+      transformations:
+        - type: 'VIVOMEDIA\Neos9\Upgrade\Transformations\DetachVariantsWithDifferentNodeTypesTransformation'
+          settings: [ ]
+down:
+  warnings: 'No down migration available'
+

--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,20 @@ migration.
 ./flow node:migrate 20241217200614
 ```
 
+### Detach variants if Node Type is different in other dimensions
+In Neos 9 it is currently not possible for Nodes with the same identifier to have different Node Types in different dimensions. 
+
+As a workaround you can detach the variants in the other dimensions and create dedicated nodes. 
+
+(!) If you need the connection between the nodes for automated translations, this will not work anymore after the migration.
+
+(!) If this hits documents nodes, the removed connection will break any language switcher, which depends on this information to switch between languages and stay on the same document. 
+
+#### Run the migration
+```bash
+./flow node:migrate 20250403150125
+```
+
 Thanks to [pkallert](https://github.com/pKallert) for providing this migration
 
 


### PR DESCRIPTION
Neos 9 has a problem if nodes with the same identifier have different NodeTypes. 
The migration assigns different identifiers in different dimensions, just like the other migration